### PR TITLE
Fixing timerdone bug

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,6 +16,7 @@
         "NO_PYTHON": "ON",
         "NO_CANLIB": "ON",
         "NO_INFLUX": "ON",
+        "TEST": "ON",
         "CMAKE_BUILD_TYPE": "Debug"
       },
       "environment": {

--- a/scripts/ECUIEmulator.py
+++ b/scripts/ECUIEmulator.py
@@ -40,10 +40,17 @@ def start_server():
 
 # Function to send JSON messages to all clients, with a custom header
 def send_message_to_all_clients(type,message):
-    msg = {
-        "type": type,
-        "content": [message,"",""]
-    }
+    if type == "sequence-start":
+        print("Starting sequence with message: %s", message)
+        msg = {
+            "type": type,
+            "content": [message,"",""]
+        }
+    else:
+        msg = {
+            "type": type,
+            "content": message
+        }
 
     str_msg = json.dumps(msg) + '\n'
     str_msg_len = len(str_msg)

--- a/src/SequenceManager.cpp
+++ b/src/SequenceManager.cpp
@@ -117,19 +117,17 @@ void SequenceManager::AbortSequence(std::string abortMsg)
 {
     if(sequenceRunning)
     {
-        EcuiSocket::SendJson("abort", abortMsg);
-        #ifndef NO_INFLUX
-        logger.log("sequence_abort", this->sequenceName + ": " + abortMsg, utils::getCurrentTimestamp());
-        #endif
         Debug::info("Aborting... " + abortMsg);
 
         sequenceToStop = true;
 		Debug::print("Asked sequence to stop...");
-		
-	sequenceThread.join();
+	    sequenceThread.join();
+	    abortSequence();
+#ifndef NO_INFLUX
+        logger.log("sequence_abort", this->sequenceName + ": " + abortMsg, utils::getCurrentTimestamp());
+#endif
+        EcuiSocket::SendJson("abort", abortMsg);
 
-
-	abortSequence();
     }
     else
     {
@@ -423,8 +421,6 @@ void SequenceManager::sequenceLoop(int64_t interval_us)
 
 		if(sequenceTime_us > endTime_us)
 		{
-			EcuiSocket::SendJson("timer-done");
-
 			sequenceToStop = true;
 		}
 
@@ -545,7 +541,7 @@ void SequenceManager::sequenceLoop(int64_t interval_us)
         Debug::log(msg + "\n");
     }
     sequenceToStop = false;
-
+    EcuiSocket::SendJson("timer-done");
     Debug::info("Sequence ended");
 
     #ifndef NO_INFLUX


### PR DESCRIPTION
This PR fixes the bug that a timer-sync message was sent after the timer-done message.
I moved the timer-done to the point where the actual sequence is finished and not where we tell it to finish in the next iteration.

The bugfix was tested on the hardware and the sequences now immediatly end at sequence end and abort.

Also I apparently didn't push the "TEST": "ON" setting in the cmake presets so I added it here.