### PR TITLE
Bugfix/llserver freeze up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,18 @@ FetchContent_MakeAvailable(readerwriterqueue)
 
 target_link_libraries(${PROJECT_NAME}_lib PUBLIC readerwriterqueue)
 
+include(FetchContent)
+
+FetchContent_Declare(
+        concurrentqueue
+        GIT_REPOSITORY    https://github.com/cameron314/concurrentqueue
+        GIT_TAG           c68072129c8a5b4025122ca5a0c82ab14b30cb03
+)
+
+FetchContent_MakeAvailable(concurrentqueue)
+
+target_link_libraries(${PROJECT_NAME}_lib PUBLIC concurrentqueue)
+
 # Create an executable that links to this library
 add_executable(${PROJECT_NAME} main.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_lib)

--- a/include/can/CanKvaserReceiveThread.h
+++ b/include/can/CanKvaserReceiveThread.h
@@ -20,6 +20,7 @@ public:
     ~CanKvaserReceiveThread();
 
     void stop();
+    void join();
     void pushMessage(std::unique_ptr<RawKvaserMessage> msg);
     [[nodiscard]] bool isRunning() const;
 
@@ -29,6 +30,8 @@ private:
     std::mutex enqueueMutex;
     std::shared_ptr<moodycamel::BlockingReaderWriterQueue<std::unique_ptr<RawKvaserMessage>> > queue;
     canRecvCallback_t onRecvCallback;
+    std::thread thread;
+
     void receiveLoop();
 };
 

--- a/include/can/Node.h
+++ b/include/can/Node.h
@@ -44,6 +44,7 @@ private:
 	static std::string databaseName;
 	static std::string measurementName;
 	static int influxBufferSize;
+	static int numberOfLoggingThreads;
 
     static InfluxDbLogger *logger;
     static std::mutex loggerMtx;

--- a/include/logging/InfluxDbLogger.h
+++ b/include/logging/InfluxDbLogger.h
@@ -11,7 +11,7 @@ class InfluxDbLogger
             InfluxDbLogger();
             InfluxDbLogger(const InfluxDbLogger&) = delete;
             ~InfluxDbLogger();
-            void Init(std::string db_hostname, unsigned db_port, std::string db_name, std::string measurement, timestamp_precision_t precision, std::size_t buffer_size);
+            void Init(std::string db_hostname, unsigned db_port, std::string db_name, std::string measurement, timestamp_precision_t precision, std::size_t buffer_size,int numberOfThreads);
 
             void log(std::string source, std::string msg, std::size_t timestamp, Severity severity);
 

--- a/include/logging/InfluxDbLogger.h
+++ b/include/logging/InfluxDbLogger.h
@@ -1,7 +1,7 @@
 #ifndef INFLUXDBLOGGER_H
 #define INFLUXDBLOGGER_H
 
-#include "logging/InfluxDbWriter.h"
+#include "logging/InfluxDbWriter.hpp"
 #include "logging/MessageLogger.h"
 #include "logging/DataLogger.h"
 
@@ -24,7 +24,7 @@ class InfluxDbLogger
 
             void flush();
         private:
-            InfluxDbWriter *dbWriter;
+            std::shared_ptr<InfluxDbWriter> dbWriter;
 };
 
 #endif

--- a/include/logging/InfluxDbSendThread.h
+++ b/include/logging/InfluxDbSendThread.h
@@ -1,0 +1,40 @@
+//
+// Created by raffael on 29.09.25.
+//
+
+#ifndef LLSERVER_ECUI_HOUBOLT_INFLUXDBSENDTHREAD_H
+#define LLSERVER_ECUI_HOUBOLT_INFLUXDBSENDTHREAD_H
+#include <atomic>
+#include <memory>
+
+#include "influxDb.h"
+#include "blockingconcurrentqueue.h"
+
+class InfluxDbWriter; // forward declaration
+
+class InfluxDbSendThread {
+public:
+    explicit InfluxDbSendThread(std::shared_ptr<influxDbContext> context,
+                       std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::string>> queue,
+                       InfluxDbWriter& influx_db_writer);
+
+    ~InfluxDbSendThread();
+
+    void stop();
+    void join(); // new: join underlying thread
+    void pushBuffer(std::string buffer);
+    [[nodiscard]] bool isRunning() const;
+
+
+private:
+    std::atomic_bool running{false};
+    std::atomic_int32_t messagesInQueue{0};
+    std::mutex enqueueMutex;
+    std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::string>> queue;
+    std::shared_ptr<influxDbContext> context;
+    std::thread thread;
+    InfluxDbWriter& writer; // reference to owning writer
+
+    void messageSendingLoop();
+};
+#endif //LLSERVER_ECUI_HOUBOLT_INFLUXDBSENDTHREAD_H

--- a/include/logging/InfluxDbSendThread.h
+++ b/include/logging/InfluxDbSendThread.h
@@ -27,13 +27,12 @@ public:
 
 private:
     std::atomic_bool running{false};
-    std::atomic_int32_t messagesInQueue{0};
     std::mutex enqueueMutex;
     std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::string>> queue;
     std::shared_ptr<influxDbContext> context;
     std::thread thread;
     InfluxDbWriter& writer; // reference to owning writer
 
-    void messageSendingLoop();
+    void messageSendingLoop() const;
 };
 #endif //LLSERVER_ECUI_HOUBOLT_INFLUXDBSENDTHREAD_H

--- a/include/logging/InfluxDbSendThread.h
+++ b/include/logging/InfluxDbSendThread.h
@@ -21,8 +21,7 @@ public:
     ~InfluxDbSendThread();
 
     void stop();
-    void join(); // new: join underlying thread
-    void pushBuffer(std::string buffer);
+    void join();
     [[nodiscard]] bool isRunning() const;
 
 

--- a/include/logging/InfluxDbWriter.h
+++ b/include/logging/InfluxDbWriter.h
@@ -6,44 +6,56 @@
 #include <vector>
 
 extern "C" {
-    #include "logging/influxDb.h"
+#include "logging/influxDb.h"
 }
 
 class InfluxDbWriter {
-    public:
-        // Might want to make the buffer size and concurrency configurable (DB)
-        InfluxDbWriter(std::string hostname, unsigned port, std::string dbName, std::size_t buffer_size);
-        InfluxDbWriter(const InfluxDbWriter&) = delete;
-        ~InfluxDbWriter();
-        void Init();
-        void setCredentials(std::string user, std::string password);
-        void setTimestampPrecision(timestamp_precision_t precision);
+public:
+    // Might want to make the buffer size and concurrency configurable (DB)
+    InfluxDbWriter(std::string hostname, unsigned port, std::string dbName, std::size_t buffer_size);
 
-        void setMeasurement(std::string measurement);
-        void startDataPoint();
-        void addTag(std::string key, std::string value);
-        void tagsDone();
-        void addField(std::string key, std::string value);
-        void addField(std::string key, std::size_t value);
-        void addField(std::string key, double value);
-        void addField(std::string key, bool value);
-        void endDataPoint(std::size_t timestamp);
+    InfluxDbWriter(const InfluxDbWriter &) = delete;
 
-        void flush();
-    private:
-        const std::size_t buffer_size = 1024;
-        const std::size_t buffer_amount = 2;
-        char **buffer = nullptr;
-        influxDbContext cntxt;
-        uint8_t buffer_sel = 0;
-        std::size_t buffer_pos = 0;
-        std::size_t last_measurement = 0;
-        std::string host, portStr, db, measurement;
-        void pushBuffer();
-        std::vector<std::thread> threads;
-        void joinThreads();
-        void push();
-        void transferPartialWrite();
+    ~InfluxDbWriter();
+
+    void Init();
+
+    void setCredentials(std::string user, std::string password);
+
+    void setTimestampPrecision(timestamp_precision_t precision);
+
+    void setMeasurement(std::string measurement);
+
+    void startDataPoint();
+
+    void addTag(std::string_view key, std::string_view value);
+
+    void tagsDone();
+
+    void addField(std::string_view key, std::string_view value);
+
+    void addField(std::string_view key, std::size_t value);
+
+    void addField(std::string_view key, double value);
+
+    void addField(std::string_view key, bool value);
+
+    void endDataPoint(std::size_t timestamp);
+
+    void flush();
+
+private:
+    const std::size_t buffer_size_max = 1024;
+    // allocations that can be reused as buffers
+    std::vector<std::string> available_buffers;
+    std::mutex buffer_mutex;
+    // the current buffer being filled
+    std::string current_buffer;
+    influxDbContext cntxt;
+    std::string host, portStr, db, measurement;
+    std::vector<std::thread> threads;
+
+    void joinThreads();
 };
 
 #endif

--- a/include/logging/InfluxDbWriter.hpp
+++ b/include/logging/InfluxDbWriter.hpp
@@ -40,10 +40,10 @@ private:
     const std::size_t buffer_size_max = 1024;
     // allocations that can be reused as buffers
     std::vector<std::string> available_buffers;
+    std::vector<std::shared_ptr<influxDbContext>> contexts;
     std::mutex buffer_mutex;
     // the current buffer being filled
     std::string current_buffer;
-    std::shared_ptr<::influxDbContext> cntxt;
     std::string host, portStr, db, measurement;
     std::vector<std::unique_ptr<InfluxDbSendThread>> threads;
     std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::string>> queue;

--- a/include/logging/InfluxDbWriter.hpp
+++ b/include/logging/InfluxDbWriter.hpp
@@ -22,7 +22,7 @@ public:
     ~InfluxDbWriter();
 
     void setCredentials(const std::string& user, const std::string& password);
-    void setTimestampPrecision(timestamp_precision_t precision);
+    void setTimestampPrecision(timestamp_precision_t precision) const;
     void setMeasurement(std::string _measurement);
 
     void startDataPoint();
@@ -48,7 +48,7 @@ private:
     std::vector<std::unique_ptr<InfluxDbSendThread>> threads;
     std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::string>> queue;
 
-    void joinThreads();
+    void joinThreads() const;
 };
 
 #endif

--- a/include/logging/InfluxDbWriter.hpp
+++ b/include/logging/InfluxDbWriter.hpp
@@ -1,48 +1,40 @@
 #ifndef INFLUXDBWRITER_H
 #define INFLUXDBWRITER_H
 
+#include <memory>
 #include <string>
 #include <thread>
 #include <vector>
+#include <mutex>
+#include "blockingconcurrentqueue.h"
 
 extern "C" {
 #include "logging/influxDb.h"
 }
 
+class InfluxDbSendThread; // forward declaration
+
 class InfluxDbWriter {
-public:
     // Might want to make the buffer size and concurrency configurable (DB)
+public:
     InfluxDbWriter(std::string hostname, unsigned port, std::string dbName, std::size_t buffer_size);
-
     InfluxDbWriter(const InfluxDbWriter &) = delete;
-
     ~InfluxDbWriter();
 
-    void Init();
-
-    void setCredentials(std::string user, std::string password);
-
+    void setCredentials(const std::string& user, const std::string& password);
     void setTimestampPrecision(timestamp_precision_t precision);
-
-    void setMeasurement(std::string measurement);
+    void setMeasurement(std::string _measurement);
 
     void startDataPoint();
-
     void addTag(std::string_view key, std::string_view value);
-
     void tagsDone();
-
     void addField(std::string_view key, std::string_view value);
-
     void addField(std::string_view key, std::size_t value);
-
     void addField(std::string_view key, double value);
-
     void addField(std::string_view key, bool value);
-
     void endDataPoint(std::size_t timestamp);
-
     void flush();
+    void returnBuffer(std::string buffer);
 
 private:
     const std::size_t buffer_size_max = 1024;
@@ -51,9 +43,10 @@ private:
     std::mutex buffer_mutex;
     // the current buffer being filled
     std::string current_buffer;
-    influxDbContext cntxt;
+    std::shared_ptr<::influxDbContext> cntxt;
     std::string host, portStr, db, measurement;
-    std::vector<std::thread> threads;
+    std::vector<std::unique_ptr<InfluxDbSendThread>> threads;
+    std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::string>> queue;
 
     void joinThreads();
 };

--- a/include/logging/InfluxDbWriter.hpp
+++ b/include/logging/InfluxDbWriter.hpp
@@ -15,9 +15,8 @@ extern "C" {
 class InfluxDbSendThread; // forward declaration
 
 class InfluxDbWriter {
-    // Might want to make the buffer size and concurrency configurable (DB)
 public:
-    InfluxDbWriter(std::string hostname, unsigned port, std::string dbName, std::size_t buffer_size);
+    InfluxDbWriter(std::string hostname, unsigned port, std::string dbName, std::size_t buffer_size, int numberOfThreads);
     InfluxDbWriter(const InfluxDbWriter &) = delete;
     ~InfluxDbWriter();
 

--- a/src/SequenceManager.cpp
+++ b/src/SequenceManager.cpp
@@ -95,7 +95,8 @@ void SequenceManager::Init(Config &config)
                     config["/INFLUXDB/database_port"],
                     config["/INFLUXDB/database_name"],
                     config["/INFLUXDB/sequences_measurement"], MICROSECONDS,
-                    config["/INFLUXDB/buffer_size"]);
+                    config["/INFLUXDB/buffer_size"],
+                    config["/INFLUXDB/number_of_sending_threads"]);
     #endif
 }
 

--- a/src/StateController.cpp
+++ b/src/StateController.cpp
@@ -24,7 +24,8 @@ void StateController::Init(std::function<void(std::string, double, double)> onSt
                      config["/INFLUXDB/database_port"],
                      config["/INFLUXDB/database_name"],
                      config["/INFLUXDB/state_measurement"], MICROSECONDS,
-                     config["/INFLUXDB/buffer_size"]);
+                     config["/INFLUXDB/buffer_size"],
+                     config["/INFLUXDB/number_of_sending_threads"]);
 #endif
         initialized = true;
     }

--- a/src/can/CANDriverKvaser.cpp
+++ b/src/can/CANDriverKvaser.cpp
@@ -72,7 +72,6 @@ CANDriverKvaser::CANDriverKvaser(canRecvCallback_t onRecvCallback,
 
 CANDriverKvaser::~CANDriverKvaser()
 {
-    receiveThread->stop();
     // Empty transfer queues (not strictly necessary but recommended by Kvaser)
     for (auto &handle : canHandlesMap)
     {
@@ -80,6 +79,8 @@ CANDriverKvaser::~CANDriverKvaser()
         (void) canBusOff(handle.second);
         (void) canClose(handle.second);
     }
+    receiveThread->stop();
+    receiveThread->join();
     canUnloadLibrary();
 }
 

--- a/src/can/CANDriverSocketCAN.cpp
+++ b/src/can/CANDriverSocketCAN.cpp
@@ -1,4 +1,4 @@
-#include "can/CANDriverSocketCAN.h"
+	#include "can/CANDriverSocketCAN.h"
 #include <utility>
 #include <string>
 #include <iostream>

--- a/src/can/CanKvaserReceiveThread.cpp
+++ b/src/can/CanKvaserReceiveThread.cpp
@@ -10,15 +10,21 @@ CanKvaserReceiveThread::CanKvaserReceiveThread(canRecvCallback_t onRecvCallback)
     onRecvCallback(onRecvCallback) {
     running = true;
 
-    std::thread([this]() { this->receiveLoop(); }).detach();
+    thread = std::thread([this]() { this->receiveLoop(); });
 }
 
 CanKvaserReceiveThread::~CanKvaserReceiveThread() {
     stop();
+    join();
 }
 
 void CanKvaserReceiveThread::stop() {
     running = false;
+}
+void CanKvaserReceiveThread::join() {
+    if (thread.joinable()) {
+        thread.join();
+    }
 }
 
 void CanKvaserReceiveThread::pushMessage(std::unique_ptr<RawKvaserMessage> msg) {

--- a/src/can/Node.cpp
+++ b/src/can/Node.cpp
@@ -73,6 +73,7 @@ int Node::influxPort;
 std::string Node::databaseName;
 std::string Node::measurementName;
 int Node::influxBufferSize;
+int Node::numberOfLoggingThreads;
 
 std::mutex Node::loggerMtx;
 
@@ -99,7 +100,8 @@ Node::Node(uint8_t nodeID, std::string nodeChannelName, NodeInfoMsg_t& nodeInfo,
                         influxPort,
                         databaseName,
                         measurementName, MICROSECONDS,
-                        influxBufferSize);
+                        influxBufferSize,
+                        numberOfLoggingThreads);
         }
         else
         {
@@ -150,6 +152,7 @@ void Node::InitConfig(Config &config) {
     databaseName = config["/INFLUXDB/database_name"];
     measurementName = config["/INFLUXDB/fast_sensor_measurement"];
     influxBufferSize = config["/INFLUXDB/fast_sensor_buffer_size"];
+    numberOfLoggingThreads = config["/INFLUXDB/fast_number_of_sending_threads"];
 }
 
 /**

--- a/src/logging/InfluxDbLogger.cpp
+++ b/src/logging/InfluxDbLogger.cpp
@@ -1,5 +1,6 @@
 #include "logging/InfluxDbLogger.h"
 #include <iostream>
+#include <utility>
 
 InfluxDbLogger::InfluxDbLogger() {
 }
@@ -8,10 +9,10 @@ InfluxDbLogger::~InfluxDbLogger() {
 }
 
 void InfluxDbLogger::Init(std::string db_hostname, unsigned db_port, std::string db_name, std::string measurement,
-                            timestamp_precision_t precision, std::size_t buffer_size) {
+                            timestamp_precision_t precision, std::size_t buffer_size,int numOfThreads) {
     try {
-        dbWriter = std::make_shared<InfluxDbWriter>(db_hostname, db_port, db_name, buffer_size);
-        dbWriter->setMeasurement(measurement);
+        dbWriter = std::make_shared<InfluxDbWriter>(db_hostname, db_port, db_name, buffer_size,numOfThreads);
+        dbWriter->setMeasurement(std::move(measurement));
         dbWriter->setTimestampPrecision(precision);
     }
     catch (const std::runtime_error &e) {

--- a/src/logging/InfluxDbLogger.cpp
+++ b/src/logging/InfluxDbLogger.cpp
@@ -5,14 +5,12 @@ InfluxDbLogger::InfluxDbLogger() {
 }
 
 InfluxDbLogger::~InfluxDbLogger() {
-    delete dbWriter;
 }
 
 void InfluxDbLogger::Init(std::string db_hostname, unsigned db_port, std::string db_name, std::string measurement,
                             timestamp_precision_t precision, std::size_t buffer_size) {
     try {
-        dbWriter = new InfluxDbWriter(db_hostname, db_port, db_name, buffer_size);
-        dbWriter->Init();
+        dbWriter = std::make_shared<InfluxDbWriter>(db_hostname, db_port, db_name, buffer_size);
         dbWriter->setMeasurement(measurement);
         dbWriter->setTimestampPrecision(precision);
     }

--- a/src/logging/InfluxDbSendThread.cpp
+++ b/src/logging/InfluxDbSendThread.cpp
@@ -50,8 +50,9 @@ void InfluxDbSendThread::messageSendingLoop() {
             sendData(context.get(), msg.data(), msg.size());
             writer.returnBuffer(std::move(msg));
         }
-        if (messagesInQueue>40) {
-            Debug::error("Queue size above 40, size: %i", messagesInQueue.load());
+        int size_approx = queue->size_approx();
+        if (size_approx>20) {
+            Debug::error("Queue size above 40, size: %i",size_approx );
         }
     }
 }

--- a/src/logging/InfluxDbSendThread.cpp
+++ b/src/logging/InfluxDbSendThread.cpp
@@ -44,15 +44,15 @@ void InfluxDbSendThread::pushBuffer(std::string msg) {
 
 void InfluxDbSendThread::messageSendingLoop() {
     while (running.load()) {
-        std::string msg;
-        if (queue->wait_dequeue_timed(msg, std::chrono::milliseconds(100))) {
+        std::string buffer;
+        if (queue->wait_dequeue_timed(buffer, std::chrono::milliseconds(100))) {
             --messagesInQueue;
-            sendData(context.get(), msg.data(), msg.size());
-            writer.returnBuffer(std::move(msg));
+            sendData(context.get(), buffer.data(), buffer.size());
+            writer.returnBuffer(std::move(buffer));
         }
         int size_approx = queue->size_approx();
-        if (size_approx>20) {
-            Debug::error("Queue size above 40, size: %i",size_approx );
+        if (size_approx>50) {
+            Debug::warning("Queue size above 50, size: %i",size_approx );
         }
     }
 }

--- a/src/logging/InfluxDbSendThread.cpp
+++ b/src/logging/InfluxDbSendThread.cpp
@@ -37,15 +37,14 @@ void InfluxDbSendThread::join() {
     if (thread.joinable()) thread.join();
 }
 
-void InfluxDbSendThread::messageSendingLoop() {
+void InfluxDbSendThread::messageSendingLoop() const {
     while (running.load()) {
         std::string buffer;
         if (queue->wait_dequeue_timed(buffer, std::chrono::milliseconds(100))) {
-            --messagesInQueue;
             sendData(context.get(), buffer.data(), buffer.size());
             writer.returnBuffer(std::move(buffer));
         }
-        int size_approx = queue->size_approx();
+        std::size_t size_approx = queue->size_approx();
         if (size_approx>50) {
             Debug::warning("Queue size above 50, size: %i",size_approx );
         }

--- a/src/logging/InfluxDbSendThread.cpp
+++ b/src/logging/InfluxDbSendThread.cpp
@@ -37,11 +37,6 @@ void InfluxDbSendThread::join() {
     if (thread.joinable()) thread.join();
 }
 
-void InfluxDbSendThread::pushBuffer(std::string msg) {
-    queue->enqueue(std::move(msg));
-    ++messagesInQueue;
-}
-
 void InfluxDbSendThread::messageSendingLoop() {
     while (running.load()) {
         std::string buffer;

--- a/src/logging/InfluxDbSendThread.cpp
+++ b/src/logging/InfluxDbSendThread.cpp
@@ -1,0 +1,54 @@
+//
+// Created by raffael on 29.09.25.
+//
+
+#include "logging/InfluxDbSendThread.h"
+
+#include <utility>
+
+#include "utility/Debug.h"
+#include "logging/InfluxDbWriter.hpp"
+
+bool InfluxDbSendThread::isRunning() const {
+    return running.load();
+}
+
+InfluxDbSendThread::InfluxDbSendThread(std::shared_ptr<influxDbContext> context,
+                                       std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::string> > queue,
+                                       InfluxDbWriter& influx_db_writer)
+    : queue(std::move(queue))
+    , context(std::move(context))
+    , writer(influx_db_writer) {
+    running = true;
+
+    thread = std::thread([this]() { this->messageSendingLoop(); });
+}
+
+InfluxDbSendThread::~InfluxDbSendThread() {
+    stop();
+    join();
+}
+
+void InfluxDbSendThread::stop() {
+    running = false;
+}
+
+void InfluxDbSendThread::join() {
+    if (thread.joinable()) thread.join();
+}
+
+void InfluxDbSendThread::pushBuffer(std::string msg) {
+    queue->enqueue(std::move(msg));
+    ++messagesInQueue;
+}
+
+void InfluxDbSendThread::messageSendingLoop() {
+    while (running.load()) {
+        std::string msg;
+        if (queue->wait_dequeue_timed(msg, std::chrono::milliseconds(100))) {
+            --messagesInQueue;
+            sendData(context.get(), msg.data(), msg.size());
+            writer.returnBuffer(std::move(msg));
+        }
+    }
+}

--- a/src/logging/InfluxDbSendThread.cpp
+++ b/src/logging/InfluxDbSendThread.cpp
@@ -50,5 +50,8 @@ void InfluxDbSendThread::messageSendingLoop() {
             sendData(context.get(), msg.data(), msg.size());
             writer.returnBuffer(std::move(msg));
         }
+        if (messagesInQueue>40) {
+            Debug::error("Queue size above 40, size: %i", messagesInQueue.load());
+        }
     }
 }

--- a/src/logging/InfluxDbWriter.cpp
+++ b/src/logging/InfluxDbWriter.cpp
@@ -143,5 +143,5 @@ void InfluxDbWriter::flush() {
 
 void InfluxDbWriter::returnBuffer(std::string buffer) {
     std::lock_guard thread_lock(buffer_mutex);
-    available_buffers.emplace_back(std::move(buffer));
+    available_buffers.push_back(std::move(buffer));
 }

--- a/src/logging/InfluxDbWriter.cpp
+++ b/src/logging/InfluxDbWriter.cpp
@@ -26,7 +26,7 @@ InfluxDbWriter::InfluxDbWriter(std::string hostname, unsigned port, std::string 
 
     queue = std::make_shared<moodycamel::BlockingConcurrentQueue<std::string>>();
     // spawn worker threads referencing *this
-    for (int i = 0; i < 2; ++i) {
+    for (int i = 0; i < 1; ++i) {
         threads.emplace_back(std::make_unique<InfluxDbSendThread>(cntxt, queue, *this));
     }
     current_buffer = std::string();

--- a/src/logging/InfluxDbWriter.cpp
+++ b/src/logging/InfluxDbWriter.cpp
@@ -29,6 +29,10 @@ InfluxDbWriter::InfluxDbWriter(std::string hostname, unsigned port, std::string 
     for (int i = 0; i < 2; ++i) {
         threads.emplace_back(std::make_unique<InfluxDbSendThread>(cntxt, queue, *this));
     }
+    current_buffer = std::string();
+    for (int i = 0; i < 10; ++i) {
+        available_buffers.emplace_back(std::string());
+    }
 }
 
 InfluxDbWriter::~InfluxDbWriter() {

--- a/src/logging/InfluxDbWriter.cpp
+++ b/src/logging/InfluxDbWriter.cpp
@@ -91,7 +91,7 @@ void InfluxDbWriter::endDataPoint(const std::size_t timestamp) {
     if (!current_buffer.empty() && current_buffer.back() == ',') {
         current_buffer.pop_back();
     }
-    std::format_to(std::back_inserter(current_buffer), " {}", timestamp);
+     std::format_to(std::back_inserter(current_buffer), " {}\n", timestamp);
     if (current_buffer.size() >= buffer_size_max) {
         flush();
     }

--- a/src/logging/InfluxDbWriter.cpp
+++ b/src/logging/InfluxDbWriter.cpp
@@ -1,41 +1,33 @@
 #include <iostream>
 
 #include "logging/InfluxDbWriter.h"
+
+#include <format>
+#include <iterator>
+#include <string>
+
 #include "logging/influxDb.h"
 #include "utility/Debug.h"
 
 using namespace std::chrono_literals;
 
-InfluxDbWriter::InfluxDbWriter(std::string hostname, unsigned port, std::string dbName, std::size_t bufferSize) : buffer_size(bufferSize) {
+InfluxDbWriter::InfluxDbWriter(std::string hostname, unsigned port, std::string dbName,
+                               std::size_t bufferSize) : buffer_size_max(bufferSize) {
     host = hostname;
     db = dbName;
     portStr = std::to_string(port);
 }
 
 void InfluxDbWriter::Init() {
-    buffer = new char*[buffer_amount];
-    for (size_t i = 0; i < buffer_amount; i++)
-    {
-        buffer[i] = new char[buffer_size];
-    }
-
-    if(initDbContext(&cntxt, host.c_str(), portStr.c_str(), db.c_str()) < 0) {
+    if (initDbContext(&cntxt, host.c_str(), portStr.c_str(), db.c_str()) < 0) {
         throw std::runtime_error("Couldn't initialize influxDbWriter (bad context)");
     }
 }
 
-InfluxDbWriter::~InfluxDbWriter() { 
-    push();
+InfluxDbWriter::~InfluxDbWriter() {
+    flush();
     joinThreads();
 
-    if(buffer != nullptr) {
-        for (size_t i = 0; i < buffer_amount; i++)
-        {
-            delete buffer[i];
-        }
-        delete buffer;
-    }
-    
     (void) deInitDbContext(&cntxt);
 }
 
@@ -50,113 +42,81 @@ void InfluxDbWriter::setTimestampPrecision(timestamp_precision_t precision) {
 }
 
 void InfluxDbWriter::setMeasurement(std::string measurement) {
-    this->measurement = measurement;
+    this->measurement = std::move(measurement);
 }
 
 void InfluxDbWriter::startDataPoint() {
-    if((buffer_size - buffer_pos) < (measurement.length())) {
-        push();
-    }
-    
-    buffer_pos += sprintf(&buffer[buffer_sel][buffer_pos], "%s", this->measurement.c_str());
+    std::format_to(std::back_inserter(current_buffer), "{}", measurement);
 }
 
-void InfluxDbWriter::addTag(std::string key, std::string value) {
-    if((buffer_size - buffer_pos) < (key.length() + value.length() + 2)) {
-        push();
-    }
-    buffer_pos += sprintf(&buffer[buffer_sel][buffer_pos], ",%s=%s", key.c_str(), value.c_str());
+void InfluxDbWriter::addTag(const std::string_view key, const std::string_view value) {
+    std::format_to(std::back_inserter(current_buffer), ",{}={}", key, value);
 }
 
 void InfluxDbWriter::tagsDone() {
-    if((buffer_size - buffer_pos) < 1) {
-        push();
-    }
-    buffer[buffer_sel][buffer_pos] = ' ';
-    buffer_pos++;
+    std::format_to(std::back_inserter(current_buffer), " ");
 }
 
 // Properly sanitize strings if needed, neglected so far because of the overhead (DB)
-void InfluxDbWriter::addField(std::string key, std::string value) {
-    if((buffer_size - buffer_pos) < (key.length() + value.length() + 4)) {
-        push();
-    }
-    buffer_pos += sprintf(&buffer[buffer_sel][buffer_pos], "%s=\"%s\",", key.c_str(), value.c_str());
+void InfluxDbWriter::addField(const std::string_view key, const std::string_view value) {
+    std::format_to(std::back_inserter(current_buffer), "{}=\"{}\",", key, value);
 }
 
-
-void InfluxDbWriter::addField(std::string key, std::size_t value) {
-    std::string str = std::to_string(value);
-    if((buffer_size - buffer_pos) < (key.length() + str.length() + 3)) {
-        push();
-    }
-    buffer_pos += sprintf(&buffer[buffer_sel][buffer_pos], "%s=%si,", key.c_str(), str.c_str());
+void InfluxDbWriter::addField(const std::string_view key, const std::size_t value) {
+    std::format_to(std::back_inserter(current_buffer), "{}={}i,", key, value);
 }
 
 // Might let user select the precision and scientific notation
-void InfluxDbWriter::addField(std::string key, double value) {
-    std::string str = std::to_string(value);
-
-    if((buffer_size - buffer_pos) < (key.length() + str.length() + 2)) {
-        push();
-    }
-    buffer_pos += sprintf(&buffer[buffer_sel][buffer_pos], "%s=%s,", key.c_str(), str.c_str());
+void InfluxDbWriter::addField(const std::string_view key, const double value) {
+    std::format_to(std::back_inserter(current_buffer), "{}={:.6f},", key, value);
 }
 
-void InfluxDbWriter::addField(std::string key, bool value) {
-    char c = value ? 't' : 'f';
-
-    if((buffer_size - buffer_pos) < (key.length() + 2)) {
-        push();
-    }
-    buffer_pos += sprintf(&buffer[buffer_sel][buffer_pos], "%s=%c,", key.c_str(), c);
+void InfluxDbWriter::addField(const std::string_view key, const bool value) {
+    std::format_to(std::back_inserter(current_buffer), "{}={},", key, value ? "t" : "f");
 }
 
-void InfluxDbWriter::endDataPoint(std::size_t timestamp) {
-    std::string ts_str = std::to_string(timestamp);
-    
-    if((buffer_size - buffer_pos) < (ts_str.length() + 1)) {
-        push();
+void InfluxDbWriter::endDataPoint(const std::size_t timestamp) {
+    // replace the last comma with a space
+    if (!current_buffer.empty() && current_buffer.back() == ',') {
+        current_buffer.pop_back();
     }
-    buffer[buffer_sel][buffer_pos-1] = ' ';
-    buffer_pos += sprintf(&buffer[buffer_sel][buffer_pos], "%s\n", ts_str.c_str());
-    last_measurement = buffer_pos-1;
-}
-
-void InfluxDbWriter::push() { 
-    // Might throw an exception if last measurement = 0 as this equals a too long entry (DB)
-    if (last_measurement > 0) {
-        joinThreads();
-        threads.push_back(std::thread(sendData, &cntxt, this->buffer[buffer_sel],  last_measurement));
-        transferPartialWrite();
-        buffer_sel = (buffer_sel + 1) & 0b1;
+    std::format_to(std::back_inserter(current_buffer), " {}", timestamp);
+    if (current_buffer.size() >= buffer_size_max) {
+        flush();
     }
-}
-
-void InfluxDbWriter::transferPartialWrite() {
-    std::size_t i = last_measurement;
-    
-    while(i < buffer_pos)
-    {
-        buffer[(buffer_sel + 1) & 0b1][i - last_measurement] = buffer[buffer_sel][i];   
-        i++;
-    }
-
-    buffer_pos = i - last_measurement;
-    last_measurement = 0;
 }
 
 void InfluxDbWriter::joinThreads() {
-    for (std::thread &t : threads) {
-        if(t.joinable()) 
-        {
-            std::this_thread::sleep_for(10ms);
-            if(t.joinable()) t.join();
-        }
-        else Debug::warning("InfluxDbWriter thread was not joinable.");
+    for (std::thread &t: threads) {
+        if (t.joinable()) {
+            t.join();
+        } else
+            Debug::warning("InfluxDbWriter thread was not joinable.");
     }
-} 
+}
 
 void InfluxDbWriter::flush() {
-    push();
+    std::lock_guard lock(buffer_mutex);
+    if (current_buffer.empty()) {
+        Debug::warning("InfluxDbWriter flush called with empty buffer, nothing to push.");
+        return;
+    }
+
+    std::string buf_to_send = std::move(current_buffer);
+
+    // get a new buffer
+    if (!available_buffers.empty()) {
+        current_buffer = std::move(available_buffers.back());
+        available_buffers.pop_back();
+    } else {
+        current_buffer.clear();
+    }
+
+    // spawn a thread to send the buffer
+    threads.emplace_back([this, buf = std::move(buf_to_send)]() mutable {
+        sendData(&cntxt, buf.data(), buf.size());
+        // return the buffer to the pool
+        std::lock_guard thread_lock(buffer_mutex);
+        available_buffers.emplace_back(std::move(buf));
+    });
 }

--- a/src/logging/influxDb.c
+++ b/src/logging/influxDb.c
@@ -95,7 +95,7 @@ static inline uint64_t monotonic_ns() {
 
 int sendData(influxDbContext *cntxt, char *data, size_t length) {
     char http_header[2048];
-    size_t ret;
+    int ret;
     size_t header_length = 0, sent = 0;
     char result[1024];
 

--- a/src/logging/influxDb.c
+++ b/src/logging/influxDb.c
@@ -10,7 +10,6 @@
 #include "logging/influxDb.h"
 #include <time.h>
 
-#define MS_TO_NS(x) ((x) * 1000000ULL)
 static void safe_str_cpy(char *src, const char *dest, size_t length) {
     strncpy(src, dest, length-1);
     src[length-1] = '\0';
@@ -86,12 +85,6 @@ int initDbContext(influxDbContext *cntxt, const char *hostname, const char *port
 int deInitDbContext(influxDbContext *cntxt) {
     return close(cntxt->sock_fd);
 }
-// Monotonic time helper (nanoseconds)
-static inline uint64_t monotonic_ns() {
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    return (uint64_t) ts.tv_sec * 1000000000ULL + (uint64_t) ts.tv_nsec;
-}
 
 int sendData(influxDbContext *cntxt, char *data, size_t length) {
     char http_header[2048];
@@ -120,12 +113,7 @@ int sendData(influxDbContext *cntxt, char *data, size_t length) {
     }
 
     // If needed -> extract response code (DB)
-    uint64_t t1 = monotonic_ns();
     read(cntxt->sock_fd, result, sizeof(result));
-    uint64_t t2 = monotonic_ns();
-    if (t2-t1>MS_TO_NS(100)) {
-        fprintf(stderr,"High read time, td= %lu, result=%s",t2-t1,result);
-    }
     return 0;
 }
 

--- a/src/logging/influxDb.c
+++ b/src/logging/influxDb.c
@@ -4,11 +4,8 @@
 #include <netdb.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <errno.h>
-//#include <zlib.h>
 
 #include "logging/influxDb.h"
-#include <time.h>
 
 static void safe_str_cpy(char *src, const char *dest, size_t length) {
     strncpy(src, dest, length-1);

--- a/src/utility/Debug.cpp
+++ b/src/utility/Debug.cpp
@@ -33,7 +33,8 @@ void Debug::Init(Config &config)
                      config["/INFLUXDB/database_port"],
                      config["/INFLUXDB/database_name"],
                      config["/INFLUXDB/debug_measurement"], MILLISECONDS,
-                     config["/INFLUXDB/buffer_size"]);
+                     config["/INFLUXDB/buffer_size"],
+                     config["/INFLUXDB/number_of_sending_threads"]);
 #endif
          initialized = true;
     }


### PR DESCRIPTION
Fixes bug, where the llserver was slowed down due to too long response times from the influx. This PR adds new sending threads, which operate entirely separately from the rest of the program. They receive messages from a new queue, which stores the full sending buffers before they are sent off.

Also, this PR un-detaches the KvaserReceiveThread. It's now stored and joined before shutdown.